### PR TITLE
Clean up deprecated assert syntax

### DIFF
--- a/lib/Auth/Process/PersistentNameID.php
+++ b/lib/Auth/Process/PersistentNameID.php
@@ -23,7 +23,7 @@ class sspmod_shib2idpnameid_Auth_Process_PersistentNameID extends sspmod_saml_Ba
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         $this->format = SAML2_Const::NAMEID_PERSISTENT;
 

--- a/lib/Auth/Process/PersistentNameID2TargetedID.php
+++ b/lib/Auth/Process/PersistentNameID2TargetedID.php
@@ -30,7 +30,7 @@ class sspmod_saml_Auth_Process_PersistentNameID2TargetedID extends SimpleSAML_Au
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        assert('is_array($config)');
+        assert(is_array($config));
 
         if (isset($config['attribute'])) {
             $this->attribute = (string) $config['attribute'];
@@ -52,7 +52,7 @@ class sspmod_saml_Auth_Process_PersistentNameID2TargetedID extends SimpleSAML_Au
      */
     public function process(&$state)
     {
-        assert('is_array($state)');
+        assert(is_array($state));
 
         if (!isset($state['saml:NameID'][SAML2_Const::NAMEID_PERSISTENT])) {
             SimpleSAML\Logger::warning('Unable to generate eduPersonTargetedID because no persistent NameID was available.');


### PR DESCRIPTION
Php 7.2 has deprecated using strings in assert statements.